### PR TITLE
Stateserver reliability changes

### DIFF
--- a/stateserver.py
+++ b/stateserver.py
@@ -211,9 +211,13 @@ def post_cancelCheck() -> Any:
     if currentShow and currentShow["connid"] == content["connid"]:
         # this show is (at least supposed to be) live now.
         # kill their show
-        do_ws_srv_telnet("NUL")
-        switch_proc = subprocess.Popen(["sel", str(SOURCE_JUKEBOX)])
-        pass
+        # but don't kill it during the news, to avoid unexpected jukeboxing
+        now = datetime.datetime.now().timestamp()
+        if now < (currentShow["endTimestamp"] - 45):
+            do_ws_srv_telnet("NUL")
+            subprocess.Popen(["sel", str(SOURCE_JUKEBOX)])
+
+    # yeet the connection
     for i in range(len(connections)):
         if connections[i]["connid"] == content["connid"]:
             connections.pop(i)


### PR DESCRIPTION
 * If someone tries registering during the news, deny it until the news is over
 * Ensure that people get brought on if they're late, even if they already have a pre-existing session
 * If someone unregisters, only switch to Jukebox if the news isn't happening
That last one (and also the first one, now that I think of it) should maybe actually check if news is due to happen? TODO