### PR TITLE
one option for dealing with a core set of reusable css animations

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -139,36 +139,6 @@ button {
   -webkit-animation: green-flash steps(1) 0.5s infinite;
   animation: green-flash steps(1) 0.5s infinite;
 }
-@-webkit-keyframes green-flash {
-  0% {
-  }
-  50% {
-    background-color: rgb(199, 255, 199);
-  }
-}
-@keyframes green-flash {
-  0% {
-  }
-  50% {
-    background-color: rgb(199, 255, 199);
-  }
-}
-
-/* Flash class and keyframe animation */
-@-webkit-keyframes red-flash {
-  0% {
-  }
-  50% {
-    background-color: rgb(255, 199, 199);
-  }
-}
-@keyframes red-flash {
-  0% {
-  }
-  50% {
-    background-color: rgb(255, 199, 199);
-  }
-}
 
 .ReactModal__Overlay {
   z-index: 10000;

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,3 +1,5 @@
+@import "./scss/base";
+
 .sp {
   display: grid;
   grid-template-areas: "channels sb-tg sb";

--- a/src/scss/_animations.scss
+++ b/src/scss/_animations.scss
@@ -1,0 +1,29 @@
+@-webkit-keyframes red-flash {
+  0% {
+  }
+  50% {
+    background-color: rgb(255, 199, 199);
+  }
+}
+@keyframes red-flash {
+  0% {
+  }
+  50% {
+    background-color: rgb(255, 199, 199);
+  }
+}
+
+@-webkit-keyframes green-flash {
+  0% {
+  }
+  50% {
+    background-color: rgb(199, 255, 199);
+  }
+}
+@keyframes green-flash {
+  0% {
+  }
+  50% {
+    background-color: rgb(199, 255, 199);
+  }
+}

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -1,0 +1,1 @@
+@import "./animations";


### PR DESCRIPTION
In a continued effort to tidy up the css, I have hit a problem where ideally some stuff like animations should be written once and reused.

There are two ways of handling something like this
- first is to import a base file in the root scss file of the application which contains or links to all the reusable code. _This PR does this_
- second is to just import the partial scss file where it is needed, i.e. in each component that uses it. However because scss isn't very smart this means that it will duplicate the code each time you import it.

