### PR TITLE
Refactor out VUMeter

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -165,5 +165,9 @@ button {
 }
 
 #micMeter {
-  margin: 0.4rem 0 0 0.6rem;
+  margin: 0.4rem 0.6rem;
+}
+
+#micMeter canvas {
+  width: 100%;
 }

--- a/src/navbar/index.tsx
+++ b/src/navbar/index.tsx
@@ -13,6 +13,7 @@ import { MYRADIO_NON_API_BASE } from "../api";
 import "./navbar.scss";
 import { closeAlert } from "./state";
 import { ConnectionStateEnum } from "../broadcast/streamer";
+import { VUMeter } from "../optionsMenu/helpers/VUMeter";
 
 function nicifyConnectionState(state: ConnectionStateEnum): string {
   switch (state) {
@@ -71,6 +72,10 @@ export function NavBar() {
       </div>
 
       <ul className="nav navbar-nav navbar-right">
+        {/*<li className="nav-item">*/}
+        {/*  <VUMeter width={400} height={40} source="master" range={[-70, 0]} />*/}
+        {/*</li>*/}
+
         <li className="nav-item" style={{ color: "white" }}>
           <div className="nav-link">
             <b>{nicifyConnectionState(broadcastState.connectionState)}</b>

--- a/src/optionsMenu/MicTab.tsx
+++ b/src/optionsMenu/MicTab.tsx
@@ -116,6 +116,7 @@ export function MicTab() {
           <VUMeter
             width={400}
             height={40}
+            source="mic-precomp"
             range={[-70, 0]}
             greenRange={[-14, -3]}
           />

--- a/src/showplanner/index.tsx
+++ b/src/showplanner/index.tsx
@@ -147,12 +147,7 @@ function MicControl() {
         </p>
       )}
       <div id="micMeter">
-        <VUMeter
-          width={400}
-          height={40}
-          range={[-70, 0]}
-          greenRange={[-14, -3]}
-        />
+        <VUMeter width={250} height={40} source="mic-final" range={[-70, 0]} />
       </div>
       <div className={`mixer-buttons ${!state.open && "disabled"}`}>
         <div


### PR DESCRIPTION
This patch adds multiple analyser nodes to the audio engine to "tap in" to the audio level at various points in the chain. Right now it's used for pre-fade and post-fade mic monitoring

It could also be used for a master level, and the code is there for it, but I'd rather implement a proper RMS/EBU meter rather than a simple peak meter for that.