### PR TITLE
Squish a memory leak

### DIFF
--- a/src/mixer/state.ts
+++ b/src/mixer/state.ts
@@ -19,6 +19,7 @@ const playerGainTweens: Array<{
   tweens: Between[];
 }> = [];
 const loadAbortControllers: AbortController[] = [];
+const lastObjectURLs: string[] = [];
 
 type PlayerStateEnum = "playing" | "paused" | "stopped";
 type PlayerRepeatEnum = "none" | "one" | "all";
@@ -297,7 +298,11 @@ export const load = (
 
     const playerInstance = await audioEngine.createPlayer(player, objectUrl);
 
-    URL.revokeObjectURL(objectUrl);
+    // Clear the last one out from memory
+    if (typeof lastObjectURLs[player] === "string") {
+      URL.revokeObjectURL(lastObjectURLs[player]);
+    }
+    lastObjectURLs[player] = objectUrl;
 
     playerInstance.on("loadComplete", (duration) => {
       console.log("loadComplete");


### PR DESCRIPTION
Revoke the object URLs we create for media, which should reduce memory consumption for long shows.