### PR TITLE
Fix ram leak caused by not destroying WaveSurfers on reload.

### DIFF
--- a/src/mixer/audio.ts
+++ b/src/mixer/audio.ts
@@ -149,6 +149,11 @@ class Player extends ((PlayerEmitter as unknown) as { new (): EventEmitter }) {
 
     return instance;
   }
+
+  cleanup() {
+    // Let wavesurfer remove the old media, otherwise ram leak!
+    this.wavesurfer.destroy();
+  }
 }
 
 export type LevelsSource = "mic-precomp" | "mic-final" | "master";
@@ -268,6 +273,16 @@ export class AudioEngine extends ((EngineEmitter as unknown) as {
     const player = Player.create(this, number, url);
     this.players[number] = player;
     return player;
+  }
+
+  // Wavesurfer needs cleanup to remove the old audio mediaelements. Memory leak!
+  public destroyPlayer(number: number) {
+    const existingPlayer = this.players[number];
+    if (existingPlayer != null) {
+      // already a player setup. Clean it.
+      existingPlayer.cleanup()
+    }
+    this.players[number] = undefined;
   }
 
   async openMic(deviceId: string) {

--- a/src/mixer/audio.ts
+++ b/src/mixer/audio.ts
@@ -276,9 +276,9 @@ export class AudioEngine extends ((EngineEmitter as unknown) as {
   }
 
   // Wavesurfer needs cleanup to remove the old audio mediaelements. Memory leak!
-  public destroyPlayer(number: number) {
+  public destroyPlayerIfExists(number: number) {
     const existingPlayer = this.players[number];
-    if (existingPlayer != null) {
+    if (existingPlayer !== undefined) {
       // already a player setup. Clean it.
       existingPlayer.cleanup();
     }

--- a/src/mixer/audio.ts
+++ b/src/mixer/audio.ts
@@ -280,7 +280,7 @@ export class AudioEngine extends ((EngineEmitter as unknown) as {
     const existingPlayer = this.players[number];
     if (existingPlayer != null) {
       // already a player setup. Clean it.
-      existingPlayer.cleanup()
+      existingPlayer.cleanup();
     }
     this.players[number] = undefined;
   }

--- a/src/mixer/state.ts
+++ b/src/mixer/state.ts
@@ -298,8 +298,7 @@ export const load = (
   if (waveform == null) {
     throw new Error();
   }
-  audioEngine.destroyPlayer(player);// clear previous (ghost) wavesurfer and it's media elements.
-  //waveform.innerHTML = "";
+  audioEngine.destroyPlayer(player); // clear previous (ghost) wavesurfer and it's media elements.
   // wavesurfer also sets the background white, remove for progress bar to work.
   waveform.style.removeProperty("background");
 

--- a/src/mixer/state.ts
+++ b/src/mixer/state.ts
@@ -298,7 +298,7 @@ export const load = (
   if (waveform == null) {
     throw new Error();
   }
-  audioEngine.destroyPlayer(player); // clear previous (ghost) wavesurfer and it's media elements.
+  audioEngine.destroyPlayerIfExists(player); // clear previous (ghost) wavesurfer and it's media elements.
   // wavesurfer also sets the background white, remove for progress bar to work.
   waveform.style.removeProperty("background");
 

--- a/src/mixer/state.ts
+++ b/src/mixer/state.ts
@@ -298,7 +298,8 @@ export const load = (
   if (waveform == null) {
     throw new Error();
   }
-  waveform.innerHTML = ""; // clear previous (ghost) wavesurfer
+  audioEngine.destroyPlayer(player);// clear previous (ghost) wavesurfer and it's media elements.
+  //waveform.innerHTML = "";
   // wavesurfer also sets the background white, remove for progress bar to work.
   waveform.style.removeProperty("background");
 


### PR DESCRIPTION
Simply deleting the HTML / Player object was leaving the MediaElementWebAudio's in memory after replacing them with a new loaded item. This causes a significant memory leak over time.