### PR TITLE
Version 1.2.4

### DIFF
--- a/.env
+++ b/.env
@@ -3,4 +3,4 @@ REACT_APP_VERSION=$npm_package_version
 REACT_APP_MYRADIO_NONAPI_BASE=https://ury.org.uk/myradio-staging
 REACT_APP_MYRADIO_BASE=https://ury.org.uk/api-staging/v2
 REACT_APP_BROADCAST_API_BASE=https://ury.org.uk/webstudio/api/v1
-REACT_APP_WS_URL=wss://audio.ury.org.uk/webstudio/stream
+REACT_APP_WS_URL=wss://ury.org.uk/webstudio/api/stream

--- a/.env.production
+++ b/.env.production
@@ -2,4 +2,4 @@ REACT_APP_VERSION=$npm_package_version
 REACT_APP_MYRADIO_NONAPI_BASE=https://ury.org.uk/myradio
 REACT_APP_MYRADIO_BASE=https://ury.org.uk/api/v2
 REACT_APP_BROADCAST_API_BASE=https://ury.org.uk/webstudio/api/v1
-REACT_APP_WS_URL=wss://audio.ury.org.uk/webstudio/stream
+REACT_APP_WS_URL=wss://ury.org.uk/webstudio/api/stream

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
         environment {
           REACT_APP_MYRADIO_NONAPI_BASE = 'https://ury.org.uk/myradio'
           REACT_APP_MYRADIO_BASE = 'https://ury.org.uk/api/v2'
-          REACT_APP_WS_URL = 'wss://audio.ury.org.uk/webstudio/stream'
+          REACT_APP_WS_URL = 'wss://ury.org.uk/webstudio/api/stream'
         }
         steps {
           sh 'sed -i -e \'s/ury.org.uk\\/webstudio-dev/ury.org.uk\\/webstudio/\' package.json'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webstudio",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "dependencies": {
     "@babel/core": "7.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webstudio",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "private": true,
   "dependencies": {
     "@babel/core": "7.6.0",

--- a/shittyserver.py
+++ b/shittyserver.py
@@ -366,7 +366,7 @@ async def serve(websocket: websockets.WebSocketServerProtocol, path: str) -> Non
 
 
 start_server = websockets.serve(
-    serve, "localhost", int(config.get("shittyserver", "websocket_port"))
+    serve, host=None, port=int(config.get("shittyserver", "websocket_port"))
 )
 
 print("Shittyserver WS starting on port {}.".format(config.get("shittyserver", "websocket_port")))

--- a/src/mixer/state.ts
+++ b/src/mixer/state.ts
@@ -519,11 +519,11 @@ export const setVolume = (
   let uiLevel: number;
   switch (level) {
     case "off":
-      volume = -36;
+      volume = -40;
       uiLevel = 0;
       break;
     case "bed":
-      volume = -7;
+      volume = -13;
       uiLevel = 0.5;
       break;
     case "full":

--- a/stateserver.py
+++ b/stateserver.py
@@ -389,11 +389,13 @@ def post_wsSessions() -> Any:
             if currentShow and currentShow["connid"] == conn["connid"]:
                 # they should be on air now, but they've just died. go to jukebox.
                 # but don't kill it during the news, or after the end time, to avoid unexpected jukeboxing
-                now = datetime.datetime.now().timestamp()
-                if now < (currentShow["endTimestamp"] - 15):
-                    print("jukeboxing due to their disappearance...")
-                    subprocess.Popen(['sel', str(SOURCE_JUKEBOX)])
-                    do_ws_srv_telnet("NUL")
+                # Also, avoid killing them if they're on a non-WS source
+                if currentShow["sourceid"] == SOURCE_WS:
+                    now = datetime.datetime.now().timestamp()
+                    if now < (currentShow["endTimestamp"] - 15):
+                        print("jukeboxing due to their disappearance...")
+                        subprocess.Popen(['sel', str(SOURCE_JUKEBOX)])
+                        do_ws_srv_telnet("NUL")
     return genPayload("Thx, K, bye.")
 
 


### PR DESCRIPTION
**Changed:**

* Route registration requests through a different server. You shouldn't notice any difference at all, this is purely a backend change.
* When a show is using something that isn't WebStudio (e.g. OB-Line), we won't Jukebox them if their connection dies
* Fixed the bed levels. Yes, again. We know we said we'd fixed it for the last time the last two times. This time they're actually, like, fixed fixed.