### PR TITLE
Save limited action history for Raygun reports

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import * as serviceWorker from "./serviceWorkerLoader";
 
 import raygun from "raygun4js";
 
-import store from "./store";
+import store, { getActionHistory } from "./store";
 import { Provider } from "react-redux";
 
 raygun("apiKey", "mtj24r3YzPoYyCG8cVArA");
@@ -21,6 +21,7 @@ if (
 raygun("withCustomData", function() {
   return {
     state: store.getState(),
+    actionHistory: getActionHistory(),
   };
 });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -33,7 +33,10 @@ const actionHistoryMiddleware: Middleware<{}, RootState, Dispatch<any>> = (
   while (actionHistory.length > ACTION_HISTORY_MAX_SIZE) {
     actionHistory.shift();
   }
-  actionHistory.push(action);
+  actionHistory.push({
+    ...action,
+    _timestamp: new Date().toString(),
+  });
   return next(action);
 };
 


### PR DESCRIPTION
The current approach is not only a little derpy, but also leads to unbounded memory usage, especially in long shows.

Instead, we only keep the latest N (currently 20) actions, and ship those as "extra data", rather than "breadcrumbs".