### PR TITLE
Only reload showplan once, don't add multiple listeners.

### DIFF
--- a/src/showplanner/ImporterModal.tsx
+++ b/src/showplanner/ImporterModal.tsx
@@ -27,7 +27,7 @@ export function ImporterModal(props: ImporterProps) {
     return () => {
       window.removeEventListener("message", reloadListener);
     };
-  });
+  }, [props]);
   return (
     <Modal isOpen={props.isOpen} onRequestClose={props.close}>
       <div>

--- a/src/showplanner/ImporterModal.tsx
+++ b/src/showplanner/ImporterModal.tsx
@@ -14,18 +14,19 @@ export function ImporterModal(props: ImporterProps) {
   // Add support for closing the modal when the importer wants to reload the show plan.
   // There is a similar listener in showplanner/index.tsx to actually reload the show plan.
   useEffect(() => {
-    window.addEventListener(
-      "message",
-      (event) => {
-        if (!event.origin.includes("ury.org.uk")) {
-          return;
-        }
-        if (event.data === "reload_showplan") {
-          props.close();
-        }
-      },
-      false
-    );
+    function reloadListener(event: MessageEvent) {
+      if (!event.origin.includes("ury.org.uk")) {
+        return;
+      }
+      if (event.data === "reload_showplan") {
+        props.close();
+      }
+    }
+
+    window.addEventListener("message", reloadListener);
+    return () => {
+      window.removeEventListener("message", reloadListener);
+    };
   });
   return (
     <Modal isOpen={props.isOpen} onRequestClose={props.close}>

--- a/src/showplanner/ImporterModal.tsx
+++ b/src/showplanner/ImporterModal.tsx
@@ -27,7 +27,7 @@ export function ImporterModal(props: ImporterProps) {
     return () => {
       window.removeEventListener("message", reloadListener);
     };
-  }, [props]);
+  });
   return (
     <Modal isOpen={props.isOpen} onRequestClose={props.close}>
       <div>

--- a/src/showplanner/index.tsx
+++ b/src/showplanner/index.tsx
@@ -374,20 +374,22 @@ const Showplanner: React.FC<{ timeslotId: number }> = function({ timeslotId }) {
   // Add support for reloading the show plan from the iFrames.
   // There is a similar listener in showplanner/ImporterModal.tsx to handle closing the iframe.
   useEffect(() => {
-    window.addEventListener(
-      "message",
-      (event) => {
-        if (!event.origin.includes("ury.org.uk")) {
-          return;
-        }
-        if (event.data === "reload_showplan") {
-          session.currentTimeslot !== null &&
-            dispatch(getShowplan(session.currentTimeslot.timeslot_id));
-        }
-      },
-      false
-    );
+    function reloadListener(event: MessageEvent) {
+      if (!event.origin.includes("ury.org.uk")) {
+        return;
+      }
+      if (event.data === "reload_showplan") {
+        session.currentTimeslot !== null &&
+          dispatch(getShowplan(session.currentTimeslot.timeslot_id));
+      }
+    }
+
+    window.addEventListener("message", reloadListener);
+    return () => {
+      window.removeEventListener("message", reloadListener);
+    };
   });
+
   if (showplan === null) {
     return (
       <LoadingDialogue

--- a/src/showplanner/index.tsx
+++ b/src/showplanner/index.tsx
@@ -388,7 +388,7 @@ const Showplanner: React.FC<{ timeslotId: number }> = function({ timeslotId }) {
     return () => {
       window.removeEventListener("message", reloadListener);
     };
-  });
+  }, [dispatch, session.currentTimeslot]);
 
   if (showplan === null) {
     return (


### PR DESCRIPTION
We were firing lots of listeners, because we kept adding them, and not removing them again. Fixes the "channel undefined" error (it's not trying to repair a show plan multiple times).