### PR TITLE
[VERY WIP] Redux refactor

### DIFF
--- a/src/broadcast/actions.ts
+++ b/src/broadcast/actions.ts
@@ -1,0 +1,8 @@
+import { createAction } from "@reduxjs/toolkit";
+
+export const REGISTERED = createAction<{ connID: number }>(
+  "Broadcast/REGISTERING"
+);
+export const CONNECTED = createAction("Broadcast/CONNECTED");
+export const GONE_LIVE = createAction("Broadcast/GONE_LIVE");
+export const DISCONNECTED = createAction("Broadcast/DISCONNECTED");

--- a/src/showplanner/state.ts
+++ b/src/showplanner/state.ts
@@ -4,6 +4,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { AppThunk } from "../store";
 import { cloneDeep } from "lodash";
 import raygun from "raygun4js";
+import { GONE_LIVE } from "../broadcast/actions";
 
 export interface ItemGhost {
   type: "ghost";
@@ -216,6 +217,12 @@ const showplan = createSlice({
       state.auxPlaylists = state.auxPlaylists.concat(action.payload);
     },
   },
+  extraReducers: (builder) =>
+    builder.addCase(GONE_LIVE, (state, action) => {
+      state.plan!.forEach((x) => {
+        x.played = true;
+      });
+    }),
 });
 
 export default showplan.reducer;


### PR DESCRIPTION
Move away from `SET_XYZ` Redux actions and to more `XYZ_HAPPENED` style - because firing multiple actions for the same "action" is a bit of a code smell (and it makes the action history harder to parse, and potentially less consistent).

At this point it's just a trial run, with BroadcastState, which is relatively small.