### PR TITLE
Fix triggering blinky play. Fixes #120

### DIFF
--- a/src/showplanner/Player.tsx
+++ b/src/showplanner/Player.tsx
@@ -192,9 +192,17 @@ function TimingButtons({ id }: { id: number }) {
 }
 
 export function Player({ id }: { id: number }) {
+  // Define time remaining (secs) when the play icon should flash.
+  const SECS_REMAINING_WARNING = 20;
+
+  // We want to force update the selector when we pass the SECS_REMAINING_WARNING barrier.
   const playerState = useSelector(
     (state: RootState) => state.mixer.players[id],
     (a, b) =>
+      !(
+        a.timeRemaining <= SECS_REMAINING_WARNING &&
+        b.timeRemaining > SECS_REMAINING_WARNING
+      ) &&
       shallowEqual(
         omit(a, "timeCurrent", "timeRemaining"),
         omit(b, "timeCurrent", "timeRemaining")
@@ -319,7 +327,7 @@ export function Player({ id }: { id: number }) {
               onClick={() => dispatch(MixerState.play(id))}
               className={
                 playerState.state === "playing"
-                  ? playerState.timeRemaining <= 15
+                  ? playerState.timeRemaining <= SECS_REMAINING_WARNING
                     ? "sp-state-playing sp-ending-soon"
                     : "sp-state-playing"
                   : ""


### PR DESCRIPTION
Previously on URY, in #120, we broke my little blinky play icon when the item is nearly finished playing.

Today it comes back again.