### PR TITLE
Reduce Item renders

### DIFF
--- a/src/showplanner/Item.tsx
+++ b/src/showplanner/Item.tsx
@@ -25,14 +25,13 @@ export const Item = memo(function Item({
   const isReal = "timeslotitemid" in x;
   const isGhost = "ghostid" in x;
 
-  const playerState = useSelector((state: RootState) =>
-    column > -1 ? state.mixer.players[column] : undefined
+  const loadedItem = useSelector(
+    (state: RootState) =>
+      column > -1 ? state.mixer.players[column]?.loadedItem : null,
+    (a, b) => a === null || b === null || itemId(a) === itemId(b)
   );
 
-  const isLoaded =
-    playerState &&
-    playerState.loadedItem !== null &&
-    itemId(playerState.loadedItem) === id;
+  const isLoaded = loadedItem !== null ? itemId(loadedItem) === id : false;
 
   const showDebug = useSelector(
     (state: RootState) => state.settings.showDebugInfo
@@ -59,14 +58,7 @@ export const Item = memo(function Item({
             "item " +
             ("played" in x ? (x.played ? "played " : "") : "") +
             x.type +
-            `${
-              column >= 0 &&
-              playerState &&
-              playerState.loadedItem !== null &&
-              itemId(playerState.loadedItem) === id
-                ? " active"
-                : ""
-            }`
+            `${column >= 0 && isLoaded ? " active" : ""}`
           }
           onClick={triggerClick}
           {...provided.draggableProps}

--- a/src/showplanner/Item.tsx
+++ b/src/showplanner/Item.tsx
@@ -28,7 +28,9 @@ export const Item = memo(function Item({
   const loadedItem = useSelector(
     (state: RootState) =>
       column > -1 ? state.mixer.players[column]?.loadedItem : null,
-    (a, b) => a === null || b === null || itemId(a) === itemId(b)
+    (a, b) =>
+      (a === null && b === null) ||
+      (a !== null && b !== null && itemId(a) === itemId(b))
   );
 
   const isLoaded = loadedItem !== null ? itemId(loadedItem) === id : false;


### PR DESCRIPTION
Item used to subscribe to the full state of the player of its column, which meant it re-rendered whenever the player state updated (many times per second) - when all it needed is the ID of the loaded item. This commit scopes the selector more tightly.

Test Plan:
* Checkout master
* Open React DevTools Profiler
* Load a track
* Start a profiling session, play a track for five seconds, stop it.
* **Observation:** many of the renders include `Item`
* Checkout this branch
* Repeat steps 2-4
* **Observation:** only `Player` and friends should be re-rendering, not `Item`