### PR TITLE
Add PFL support

### DIFF
--- a/src/mixer/audio.ts
+++ b/src/mixer/audio.ts
@@ -176,8 +176,6 @@ class Player extends ((PlayerEmitter as unknown) as { new (): EventEmitter }) {
 
   _connectPFL() {
     if (this.pfl) {
-      console.log("Connecting PFL");
-
       // In this case, we just want to route the player output to the headphones direct.
       // Tap it from analyser to avoid the player volume.
       (this.wavesurfer as any).backend.analyser.connect(
@@ -189,7 +187,7 @@ class Player extends ((PlayerEmitter as unknown) as { new (): EventEmitter }) {
           this.engine.headphonesNode
         );
       } catch (e) {
-        console.log("Didn't disconnect.");
+        // This connection wasn't connected anyway, ignore.
       }
     }
   }
@@ -469,10 +467,11 @@ export class AudioEngine extends ((EngineEmitter as unknown) as {
     this.headphonesNode.connect(this.pflAnalyser);
   }
 
-  _connectFinalCompressor(headphones: boolean) {
+  // Routes the final compressor (all players) to the stream, and optionally headphones.
+  _connectFinalCompressor(masterToHeadphones: boolean) {
     this.finalCompressor.disconnect();
 
-    if (headphones) {
+    if (masterToHeadphones) {
       // Send the final compressor (all players and guests) to the headphones.
       this.finalCompressor.connect(this.headphonesNode);
     }

--- a/src/mixer/audio.ts
+++ b/src/mixer/audio.ts
@@ -25,6 +25,7 @@ const PlayerEmitter: StrictEmitter<
 class Player extends ((PlayerEmitter as unknown) as { new (): EventEmitter }) {
   private volume = 0;
   private trim = 0;
+  private pfl = false;
   private constructor(
     private readonly engine: AudioEngine,
     private wavesurfer: WaveSurfer,
@@ -140,6 +141,11 @@ class Player extends ((PlayerEmitter as unknown) as { new (): EventEmitter }) {
     this._applyVolume();
   }
 
+  setPFL(enabled: boolean) {
+    this.pfl = enabled;
+    this._applyPFL();
+  }
+
   setOutputDevice(sinkId: string) {
     if (!this.customOutput) {
       throw Error(
@@ -167,6 +173,10 @@ class Player extends ((PlayerEmitter as unknown) as { new (): EventEmitter }) {
         (this.wavesurfer as any).backend.gainNode.gain.value = linear;
       }
     }
+  }
+
+  _applyPFL() {
+    console.log("Do something");
   }
 
   public static create(

--- a/src/mixer/state.ts
+++ b/src/mixer/state.ts
@@ -781,8 +781,16 @@ export const setChannelPFL = (
     dispatch(setVolume(player, "off", false));
     dispatch(play(player));
   }
-  dispatch(mixerState.actions.setPlayerPFL({ player, enabled }));
-  audioEngine.setPFL(player, enabled);
+  // If the player number is -1, do all channels.
+  if (player === -1) {
+    for (let i = 0; i < audioEngine.players.length; i++) {
+      dispatch(mixerState.actions.setPlayerPFL({ player: i, enabled: false }));
+      audioEngine.setPFL(i, false);
+    }
+  } else {
+    dispatch(mixerState.actions.setPlayerPFL({ player, enabled }));
+    audioEngine.setPFL(player, enabled);
+  }
 };
 
 export const openMicrophone = (

--- a/src/mixer/state.ts
+++ b/src/mixer/state.ts
@@ -595,7 +595,11 @@ const attemptTracklist = (player: number): AppThunk => async (
   getState
 ) => {
   const state = getState().mixer.players[player];
-  if (state.loadedItem && "album" in state.loadedItem) {
+  if (
+    state.loadedItem &&
+    "album" in state.loadedItem &&
+    audioEngine.players[player]?.isPlaying
+  ) {
     //track
     console.log("potentially tracklisting", state.loadedItem);
     if (state.tracklistItemID === -1) {

--- a/src/mixer/state.ts
+++ b/src/mixer/state.ts
@@ -370,6 +370,7 @@ export const load = (
   const shouldResetTrim = getState().settings.resetTrimOnLoad;
   const customOutput =
     getState().settings.channelOutputIds[player] !== "internal";
+  const isPFL = getState().mixer.players[player].pfl;
 
   dispatch(
     mixerState.actions.loadItem({
@@ -438,6 +439,7 @@ export const load = (
     const playerInstance = await audioEngine.createPlayer(
       player,
       channelOutputId,
+      isPFL,
       objectUrl
     );
 

--- a/src/mixer/state.ts
+++ b/src/mixer/state.ts
@@ -760,11 +760,13 @@ export const setChannelPFL = (
   player: number,
   enabled: boolean
 ): AppThunk => async (dispatch) => {
-  if (typeof audioEngine.players[player] !== "undefined") {
-    if (!audioEngine.players[player]?.isPlaying) {
-      dispatch(setVolume(player, "off", false));
-      dispatch(play(player));
-    }
+  if (
+    enabled &&
+    typeof audioEngine.players[player] !== "undefined" &&
+    !audioEngine.players[player]?.isPlaying
+  ) {
+    dispatch(setVolume(player, "off", false));
+    dispatch(play(player));
   }
   dispatch(mixerState.actions.setPlayerPFL({ player, enabled }));
   audioEngine.setPFL(player, enabled);

--- a/src/mixer/state.ts
+++ b/src/mixer/state.ts
@@ -745,8 +745,8 @@ export const setChannelPFL = (
   player: number,
   enabled: boolean
 ): AppThunk => async (dispatch) => {
-  dispatch(mixerState.actions.setPlayerPFL({ player, enabled: enabled }));
-  audioEngine.players[player]?.setPFL(enabled);
+  dispatch(mixerState.actions.setPlayerPFL({ player, enabled }));
+  audioEngine.setPFL(player, enabled);
 };
 
 export const openMicrophone = (

--- a/src/mixer/state.ts
+++ b/src/mixer/state.ts
@@ -38,6 +38,7 @@ interface PlayerState {
   volume: number;
   gain: number;
   trim: number;
+  pfl: boolean;
   timeCurrent: number;
   timeRemaining: number;
   timeLength: number;
@@ -68,6 +69,7 @@ const BasePlayerState: PlayerState = {
   volume: 1,
   gain: 0,
   trim: defaultTrimDB,
+  pfl: false,
   timeCurrent: 0,
   timeRemaining: 0,
   timeLength: 0,
@@ -166,6 +168,15 @@ const mixerState = createSlice({
       }>
     ) {
       state.players[action.payload.player].trim = action.payload.trim;
+    },
+    setPlayerPFL(
+      state,
+      action: PayloadAction<{
+        player: number;
+        enabled: boolean;
+      }>
+    ) {
+      state.players[action.payload.player].pfl = action.payload.enabled;
     },
     setLoadedItemIntro(
       state,
@@ -728,6 +739,14 @@ export const setChannelTrim = (player: number, val: number): AppThunk => async (
 ) => {
   dispatch(mixerState.actions.setPlayerTrim({ player, trim: val }));
   audioEngine.players[player]?.setTrim(val);
+};
+
+export const setChannelPFL = (
+  player: number,
+  enabled: boolean
+): AppThunk => async (dispatch) => {
+  dispatch(mixerState.actions.setPlayerPFL({ player, enabled: enabled }));
+  audioEngine.players[player]?.setPFL(enabled);
 };
 
 export const openMicrophone = (

--- a/src/navbar/index.tsx
+++ b/src/navbar/index.tsx
@@ -164,6 +164,13 @@ export function NavBarMain() {
   const dispatch = useDispatch();
   const broadcastState = useSelector((state: RootState) => state.broadcast);
   const settings = useSelector((state: RootState) => state.settings);
+  const playerState = useSelector((state: RootState) => state.mixer.players);
+
+  let playerPFLs: boolean[] = [];
+  playerState.forEach((player) => {
+    playerPFLs.push(player.pfl);
+  });
+  const isPFL = useSelector((state) => playerPFLs).some((x) => x === true);
 
   const [connectButtonAnimating, setConnectButtonAnimating] = useState(false);
 
@@ -290,20 +297,20 @@ export function NavBarMain() {
         >
           <FaCog size={17} /> Options
         </li>
-        {settings.proMode && (
+        {settings.proMode && isPFL && (
           <li
-            className="btn btn-danger rounded-0 pt-2 pb-1 nav-item nav-link"
+            className="btn btn-danger rounded-0 pt-2 pb-1 nav-item nav-link clear-pfl"
             onClick={() => dispatch(setChannelPFL(-1, false))}
           >
             <FaHeadphonesAlt size={17} /> Clear PFL
           </li>
         )}
 
-        <li className="nav-item px-2 nav-vu">
+        <li className={"nav-item px-2 nav-vu" + (isPFL ? " pfl-live" : "")}>
           <VUMeter
             width={235}
-            height={40}
-            source="master"
+            height={isPFL ? 32 : 40}
+            source={isPFL ? "pfl" : "master"}
             range={[-40, 3]}
             stereo={true}
           />

--- a/src/navbar/index.tsx
+++ b/src/navbar/index.tsx
@@ -11,6 +11,7 @@ import {
   FaSpinner,
   FaExclamationTriangle,
   FaCog,
+  FaHeadphonesAlt,
 } from "react-icons/fa";
 
 import { RootState } from "../rootReducer";
@@ -26,6 +27,7 @@ import { VUMeter } from "../optionsMenu/helpers/VUMeter";
 import { getShowplan, setItemPlayed } from "../showplanner/state";
 
 import * as OptionsMenuState from "../optionsMenu/state";
+import { setChannelPFL } from "../mixer/state";
 
 function nicifyConnectionState(state: ConnectionStateEnum): string {
   switch (state) {
@@ -288,6 +290,14 @@ export function NavBarMain() {
         >
           <FaCog size={17} /> Options
         </li>
+        {settings.proMode && (
+          <li
+            className="btn btn-danger rounded-0 pt-2 pb-1 nav-item nav-link"
+            onClick={() => dispatch(setChannelPFL(-1, false))}
+          >
+            <FaHeadphonesAlt size={17} /> Clear PFL
+          </li>
+        )}
 
         <li className="nav-item px-2 nav-vu">
           <VUMeter

--- a/src/navbar/index.tsx
+++ b/src/navbar/index.tsx
@@ -309,7 +309,7 @@ export function NavBarMain() {
         <li className={"nav-item px-2 nav-vu" + (isPFL ? " pfl-live" : "")}>
           <VUMeter
             width={235}
-            height={isPFL ? 32 : 40}
+            height={isPFL ? 34 : 40}
             source={isPFL ? "pfl" : "master"}
             range={[-40, 3]}
             stereo={true}

--- a/src/navbar/index.tsx
+++ b/src/navbar/index.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { shallowEqual, useDispatch, useSelector } from "react-redux";
 import Clock from "react-live-clock";
 import Stopwatch from "react-stopwatch";
 
@@ -161,31 +161,6 @@ export function NavBarMyRadio() {
 }
 
 export function NavBarMain() {
-  const dispatch = useDispatch();
-  const broadcastState = useSelector((state: RootState) => state.broadcast);
-  const settings = useSelector((state: RootState) => state.settings);
-  const playerState = useSelector((state: RootState) => state.mixer.players);
-
-  let playerPFLs: boolean[] = [];
-  playerState.forEach((player) => {
-    playerPFLs.push(player.pfl);
-  });
-  const isPFL = useSelector((state) => playerPFLs).some((x) => x === true);
-
-  const [connectButtonAnimating, setConnectButtonAnimating] = useState(false);
-
-  const prevRegistrationStage = useRef(broadcastState.stage);
-  useEffect(() => {
-    if (broadcastState.stage !== prevRegistrationStage.current) {
-      setConnectButtonAnimating(false);
-    }
-    prevRegistrationStage.current = broadcastState.stage;
-  }, [broadcastState.stage]);
-
-  const { planSaveError, planSaving } = useSelector(
-    (state: RootState) => state.showplan
-  );
-
   return (
     <>
       <ul className="nav navbar-nav navbar-left">
@@ -207,115 +182,188 @@ export function NavBarMain() {
             timezone={"europe/london"}
           />
         </li>
-        {planSaving && (
-          <li className="btn rounded-0 py-2 nav-item alert-info">
-            <FaSpinner className="nav-spin mb-1" /> Saving show plan...
-          </li>
-        )}
-        {planSaveError && (
-          <li className="btn rounded-0 py-2 nav-item alert-danger">
-            <FaExclamationTriangle className="p-0 mr-1" />
-            {planSaveError}
-          </li>
-        )}
+        <SavingAlert />
       </ul>
-
       <ul className="nav navbar-nav navbar-right mr-0 pr-0">
-        <li className="nav-item" style={{ color: "white" }}>
-          <div className="nav-link">
-            <b>{nicifyConnectionState(broadcastState.connectionState)}</b>
-          </div>
+        <RegisterButton />
+        <RecordingButton />
+        <OptionsButton />
+        <MeterBridge />
+      </ul>
+    </>
+  );
+}
+function SavingAlert() {
+  const { planSaveError, planSaving } = useSelector(
+    (state: RootState) => state.showplan
+  );
+  return (
+    <>
+      {planSaving && (
+        <li className="btn rounded-0 py-2 nav-item alert-info">
+          <FaSpinner className="nav-spin mb-1" /> Saving show plan...
         </li>
+      )}
+      {planSaveError && (
+        <li className="btn rounded-0 py-2 nav-item alert-danger">
+          <FaExclamationTriangle className="p-0 mr-1" />
+          {planSaveError}
+        </li>
+      )}
+    </>
+  );
+}
+function RegisterButton() {
+  const dispatch = useDispatch();
+  const broadcastState = useSelector((state: RootState) => state.broadcast);
+  const [connectButtonAnimating, setConnectButtonAnimating] = useState(false);
+
+  const prevRegistrationStage = useRef(broadcastState.stage);
+  useEffect(() => {
+    if (broadcastState.stage !== prevRegistrationStage.current) {
+      setConnectButtonAnimating(false);
+    }
+    prevRegistrationStage.current = broadcastState.stage;
+  }, [broadcastState.stage]);
+
+  return (
+    <>
+      <li className="nav-item" style={{ color: "white" }}>
+        <div className="nav-link">
+          <b>{nicifyConnectionState(broadcastState.connectionState)}</b>
+        </div>
+      </li>
+      <li
+        className="btn btn-outline-light rounded-0 pt-2 pb-1 nav-item nav-link connect"
+        onClick={() => {
+          setConnectButtonAnimating(true);
+          switch (broadcastState.stage) {
+            case "NOT_REGISTERED":
+              dispatch(BroadcastState.goOnAir());
+              break;
+            case "REGISTERED":
+              dispatch(BroadcastState.cancelTimeslot());
+              break;
+          }
+        }}
+      >
+        {connectButtonAnimating ? (
+          <>
+            <FaBroadcastTower size={17} className="mr-2" />
+            <FaSpinner size={17} className="nav-spin mr-2" />
+          </>
+        ) : (
+          <>
+            <FaBroadcastTower size={17} className="mr-2" />
+            {broadcastState.stage === "NOT_REGISTERED" && "Register"}
+            {broadcastState.stage === "REGISTERED" && "Stop"}
+          </>
+        )}
+      </li>
+    </>
+  );
+}
+function RecordingButton() {
+  const recordingState = useSelector(
+    (state: RootState) => state.broadcast.recordingState
+  );
+  const enableRecording = useSelector(
+    (state: RootState) => state.settings.enableRecording
+  );
+  const dispatch = useDispatch();
+  return (
+    <>
+      {enableRecording && (
         <li
-          className="btn btn-outline-light rounded-0 pt-2 pb-1 nav-item nav-link connect"
-          onClick={() => {
-            setConnectButtonAnimating(true);
-            switch (broadcastState.stage) {
-              case "NOT_REGISTERED":
-                dispatch(BroadcastState.goOnAir());
-                break;
-              case "REGISTERED":
-                dispatch(BroadcastState.cancelTimeslot());
-                break;
-            }
-          }}
+          className={
+            "btn rounded-0 pt-2 pb-1 nav-item nav-link " +
+            (recordingState === "CONNECTED"
+              ? "btn-outline-danger active"
+              : "btn-outline-light")
+          }
+          onClick={() =>
+            dispatch(
+              recordingState === "NOT_CONNECTED"
+                ? BroadcastState.startRecording()
+                : BroadcastState.stopRecording()
+            )
+          }
         >
-          {connectButtonAnimating ? (
-            <>
-              <FaBroadcastTower size={17} className="mr-2" />
-              <FaSpinner size={17} className="nav-spin mr-2" />
-            </>
+          <FaCircle
+            size={17}
+            className={
+              recordingState === "CONNECTED" ? "rec-blink" : "rec-stop"
+            }
+          />{" "}
+          {recordingState === "CONNECTED" ? (
+            <Stopwatch
+              seconds={0}
+              minutes={0}
+              hours={0}
+              render={({ formatted }) => {
+                return <span>{formatted}</span>;
+              }}
+            />
           ) : (
-            <>
-              <FaBroadcastTower size={17} className="mr-2" />
-              {broadcastState.stage === "NOT_REGISTERED" && "Register"}
-              {broadcastState.stage === "REGISTERED" && "Stop"}
-            </>
+            "Record"
           )}
         </li>
-        {settings.enableRecording && (
-          <li
-            className={
-              "btn rounded-0 pt-2 pb-1 nav-item nav-link " +
-              (broadcastState.recordingState === "CONNECTED"
-                ? "btn-outline-danger active"
-                : "btn-outline-light")
-            }
-            onClick={() =>
-              dispatch(
-                broadcastState.recordingState === "NOT_CONNECTED"
-                  ? BroadcastState.startRecording()
-                  : BroadcastState.stopRecording()
-              )
-            }
-          >
-            <FaCircle
-              size={17}
-              className={
-                broadcastState.recordingState === "CONNECTED"
-                  ? "rec-blink"
-                  : "rec-stop"
-              }
-            />{" "}
-            {broadcastState.recordingState === "CONNECTED" ? (
-              <Stopwatch
-                seconds={0}
-                minutes={0}
-                hours={0}
-                render={({ formatted }) => {
-                  return <span>{formatted}</span>;
-                }}
-              />
-            ) : (
-              "Record"
-            )}
-          </li>
-        )}
-        <li
-          className="btn btn-outline-light rounded-0 pt-2 pb-1 nav-item nav-link"
-          onClick={() => dispatch(OptionsMenuState.open())}
-        >
-          <FaCog size={17} /> Options
-        </li>
-        {settings.proMode && isPFL && (
-          <li
-            className="btn btn-danger rounded-0 pt-2 pb-1 nav-item nav-link clear-pfl"
-            onClick={() => dispatch(setChannelPFL(-1, false))}
-          >
-            <FaHeadphonesAlt size={17} /> Clear PFL
-          </li>
-        )}
+      )}
+    </>
+  );
+}
+function OptionsButton() {
+  const dispatch = useDispatch();
+  return (
+    <li
+      className="btn btn-outline-light rounded-0 pt-2 pb-1 nav-item nav-link"
+      onClick={() => dispatch(OptionsMenuState.open())}
+    >
+      <FaCog size={17} /> Options
+    </li>
+  );
+}
 
-        <li className={"nav-item px-2 nav-vu" + (isPFL ? " pfl-live" : "")}>
+function MeterBridge() {
+  const dispatch = useDispatch();
+  const proMode = useSelector((state: RootState) => state.settings.proMode);
+  const playerPFLs = useSelector(
+    (state: RootState) => state.mixer.players.map((x) => x.pfl),
+    shallowEqual
+  );
+  const isPFL = useSelector((state) => playerPFLs).some((x) => x === true);
+
+  return (
+    <>
+      {proMode && isPFL && (
+        <li
+          className="btn btn-danger rounded-0 pt-2 pb-1 nav-item nav-link clear-pfl"
+          onClick={() => dispatch(setChannelPFL(-1, false))}
+        >
+          <FaHeadphonesAlt size={17} /> Clear PFL
+        </li>
+      )}
+
+      <li className={"nav-item px-2 nav-vu" + (isPFL ? " pfl-live" : "")}>
+        {isPFL && (
           <VUMeter
             width={235}
-            height={isPFL ? 34 : 40}
-            source={isPFL ? "pfl" : "master"}
+            height={34}
+            source="pfl"
             range={[-40, 3]}
             stereo={true}
           />
-        </li>
-      </ul>
+        )}
+        {!isPFL && (
+          <VUMeter
+            width={235}
+            height={40}
+            source="master"
+            range={[-40, 3]}
+            stereo={true}
+          />
+        )}
+      </li>
     </>
   );
 }

--- a/src/navbar/navbar.scss
+++ b/src/navbar/navbar.scss
@@ -305,3 +305,8 @@
 .nav-link.connect {
   min-width: 90px;
 }
+
+.pfl-live.nav-vu {
+  box-shadow: inset 0 0 3px 6px #dc3545;
+  padding-top: 6px;
+}

--- a/src/showplanner/ProModeButtons.tsx
+++ b/src/showplanner/ProModeButtons.tsx
@@ -1,15 +1,18 @@
 import React, { useState } from "react";
-import { FaTachometerAlt } from "react-icons/fa";
+import { FaHeadphonesAlt, FaTachometerAlt } from "react-icons/fa";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../rootReducer";
-import { setChannelTrim } from "../mixer/state";
+import { setChannelTrim, setChannelPFL } from "../mixer/state";
 
-type ButtonIds = "trim";
+type ButtonIds = "trim" | "pfl";
 
 export default function ProModeButtons({ channel }: { channel: number }) {
   const [activeButton, setActiveButton] = useState<ButtonIds | null>(null);
   const trimVal = useSelector(
     (state: RootState) => state.mixer.players[channel]?.trim
+  );
+  const pflState = useSelector(
+    (state: RootState) => state.mixer.players[channel]?.pfl
   );
   const dispatch = useDispatch();
 
@@ -17,17 +20,27 @@ export default function ProModeButtons({ channel }: { channel: number }) {
     <>
       <div className="row m-0 p-1 card-header channelButtons proMode hover-menu">
         <span className="hover-label">Pro Mode&trade;</span>
-        {(activeButton === null || activeButton === "trim") && (
-          <button
-            className="btn btn-warning"
-            title="Trim"
-            onClick={() =>
-              setActiveButton(activeButton === "trim" ? null : "trim")
-            }
-          >
-            <FaTachometerAlt />
-          </button>
-        )}
+        <button
+          className="mr-1 btn btn-warning"
+          title="Trim"
+          onClick={() =>
+            setActiveButton(activeButton === "trim" ? null : "trim")
+          }
+        >
+          <FaTachometerAlt />
+        </button>
+        <button
+          className={
+            "mr-1 btn " + (pflState ? "btn-danger" : "btn-outline-dark")
+          }
+          title="PFL Channel"
+          onClick={() => {
+            dispatch(setChannelPFL(channel, !pflState));
+            setActiveButton("pfl");
+          }}
+        >
+          <FaHeadphonesAlt />
+        </button>
         {activeButton === "trim" && (
           <>
             <input
@@ -42,8 +55,13 @@ export default function ProModeButtons({ channel }: { channel: number }) {
                 e.target.blur(); // Stop dragging from disabling the keyboard triggers.
               }}
             />
-            <b>{trimVal} dB</b>
+            <strong className="mt-2">{trimVal} dB</strong>
           </>
+        )}
+        {activeButton === "pfl" && (
+          <span className="mt-2 ml-2">
+            Pre Fader Listen:&nbsp;<strong>{pflState ? "Yes" : "No"}</strong>
+          </span>
         )}
       </div>
     </>


### PR DESCRIPTION
Finally! PFL support for WebStudio!

- Turn it on and off per channel at any time.
- PFL'ing when not playing will play with fader off, as would the Sonifex.
- Tracklisting now is now fader aware, it will only tracklist at the start of a song having it's fader turned on. Fixes #79

Todo:
- [x] Add a clear PFL button.
- [x] Hide PFL button if custom outputs applied (it won't work)
- [x] Maybe headphone volume monitor meter / volume control? 