### PR TITLE
Default to saving changes to showplan, and add notice

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "fs-extra": "7.0.1",
     "html-webpack-plugin": "4.0.0-beta.5",
     "identity-obj-proxy": "3.0.0",
+    "immer": "^8.0.1",
     "is-wsl": "^1.1.0",
     "jest": "24.9.0",
     "jest-environment-jsdom-fourteen": "0.1.0",

--- a/src/rootReducer.ts
+++ b/src/rootReducer.ts
@@ -1,6 +1,11 @@
 import { combineReducers } from "@reduxjs/toolkit";
 
-import { persistReducer, PersistConfig } from "redux-persist";
+import {
+  persistReducer,
+  PersistConfig,
+  createMigrate,
+  PersistedState,
+} from "redux-persist";
 import webStorage from "redux-persist/lib/storage";
 import autoMergeLevel2 from "redux-persist/lib/stateReconciler/autoMergeLevel2";
 
@@ -11,6 +16,7 @@ import sessionReducer from "./session/state";
 import NavbarReducer from "./navbar/state";
 import OptionsMenuReducer from "./optionsMenu/state";
 import SettingsState from "./optionsMenu/settingsState";
+import produce from "immer";
 
 const rootReducer = combineReducers({
   showplan: ShowplanReducer,
@@ -22,15 +28,28 @@ const rootReducer = combineReducers({
   settings: SettingsState,
 });
 
-export type RootState = ReturnType<typeof rootReducer>;
+const persistMigrations = createMigrate({
+  0: (state) =>
+    produce(
+      state,
+      (x: PersistedState & Pick<_InternalRootState, "settings">) => {
+        x.settings.saveShowPlanChanges = true;
+      }
+    ),
+});
 
-const persistenceConfig: PersistConfig<RootState> = {
+type _InternalRootState = ReturnType<typeof rootReducer>;
+
+const persistenceConfig: PersistConfig<_InternalRootState> = {
   key: "root",
   storage: webStorage,
   whitelist: ["settings"],
   stateReconciler: autoMergeLevel2,
+  version: 0,
+  migrate: persistMigrations,
 };
 
 const persistedReducer = persistReducer(persistenceConfig, rootReducer);
 
+export type RootState = ReturnType<typeof persistedReducer>;
 export default persistedReducer;

--- a/src/showplanner/PISModal.tsx
+++ b/src/showplanner/PISModal.tsx
@@ -3,6 +3,8 @@ import Modal from "react-modal";
 import { getLatestNewsItem, NewsEntry } from "../api";
 import { Button } from "reactstrap";
 import { FaTimes } from "react-icons/fa";
+import { RootState } from "../rootReducer";
+import { useSelector } from "react-redux";
 
 function DevWarning() {
   if (process.env.REACT_APP_PRODUCTION === "true") {
@@ -23,6 +25,38 @@ function DevWarning() {
         <br />
         For the latest and greatest tested WebStudio, go to{" "}
         <a href={wsUrl}>{wsUrl}</a>.
+      </div>
+      <hr />
+    </>
+  );
+}
+
+function PersistNotice() {
+  const stateVersion = useSelector(
+    (state: RootState) => state._persist.version
+  );
+  const saving = useSelector(
+    (state: RootState) => state.settings.saveShowPlanChanges
+  );
+  if (stateVersion !== 0 || !saving) {
+    return null;
+  }
+  return (
+    <>
+      <div className="p-2 alert-primary">
+        <h2>Welcome to WebStudio {process.env.REACT_APP_VERSION}!</h2>
+        <p>
+          As of this version,{" "}
+          <strong>
+            changes to your show plan will be saved automatically.
+          </strong>
+          &nbsp; You no longer need to use Show Planner to save changes to your
+          show.
+        </p>
+        <p>
+          If you encounter any issues with saving changes, please let the
+          Computing Team know in #computing on URY Slack. Thanks, and have fun!
+        </p>
       </div>
       <hr />
     </>
@@ -67,6 +101,7 @@ export function PisModal({
       </Button>
       <hr className="mt-1 mb-3" />
       <DevWarning />
+      <PersistNotice />
       {(news === "loading" || news === "not_loaded") && (
         <p>Loading the news...</p>
       )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6134,6 +6134,11 @@ immer@^6.0.1:
   resolved "https://registry.yarnpkg.com/immer/-/immer-6.0.5.tgz#77187d13b71c6cee40dde3b8e87a50a7a636d630"
   integrity sha512-Q2wd90qrgFieIpLzAO2q9NLEdmyp/sr76Ml4Vm5peUKgyTa2CQa3ey8zuzwSKOlKH7grCeGBGUcLLVCVW1aguA==
 
+immer@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
+  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"


### PR DESCRIPTION
This PR introduces an upgrade system for the settings state, and adds a migration from version -1 to 0 to default to saving show plan changes to server. It also adds a notice on the initial PIS modal.

Should be released to prod at the same time as https://github.com/UniversityRadioYork/MyRadio/pull/980.