### PR TITLE
Defocus library dropdown when adding item

### DIFF
--- a/src/showplanner/index.tsx
+++ b/src/showplanner/index.tsx
@@ -170,10 +170,15 @@ const Showplanner: React.FC<{ timeslotId: number }> = function({ timeslotId }) {
         ])
       );
     }
-    // If we're dragging from a pseudo-column, and a search field is focused, defocus it.
+    // If we're dragging from a pseudo-column,
+    // and a search field or library dropdown is focused, defocus it.
     if (result.source.droppableId[0] === "$") {
       const focus = document.activeElement;
-      if (focus && focus instanceof HTMLInputElement && focus.type === "text") {
+      if (
+        (focus && focus instanceof HTMLInputElement && focus.type === "text") ||
+        (focus instanceof HTMLSelectElement &&
+          focus.id === "sidebarLibrarySelect")
+      ) {
         focus.blur();
       }
     }

--- a/src/showplanner/libraries.tsx
+++ b/src/showplanner/libraries.tsx
@@ -115,6 +115,7 @@ export function LibraryColumn() {
         </div>
         <div className="px-2">
           <select
+            id="sidebarLibrarySelect"
             className="form-control form-control-sm"
             style={{ flex: "none" }}
             value={sauce}


### PR DESCRIPTION
In #163 we defocus the search box when we drag in an item. However, you can still select a non-music library, drag things in, have the dropdown stay focused, and thus eat hotkeys. This defocuses it as well.