### PR TITLE
Fix "repair failed"

### DIFF
--- a/src/showplanner/state.ts
+++ b/src/showplanner/state.ts
@@ -551,8 +551,8 @@ export const getShowplan = (timeslotId: number): AppThunk => async (
           ops.push({
             op: "MoveItem",
             timeslotitemid: item.timeslotitemid,
-            oldchannel: colIndex,
-            channel: colIndex,
+            oldchannel: item.channel,
+            channel: item.channel,
             oldweight: item.weight,
             weight: itemIndex,
           });


### PR DESCRIPTION
In a showplan with nothing in column 0 or 1 that is corrupt (has non-consecutive item weights), the repair code would generate invalid operations, because it used the index of the channel it was repairing rather than the correct channel number.

(Note: I haven't tested this yet.)