### PR TITLE
Highlight tracks that could violate PPL rules

### DIFF
--- a/src/mixer/state.ts
+++ b/src/mixer/state.ts
@@ -6,7 +6,7 @@ import {
 } from "@reduxjs/toolkit";
 import fetchProgress, { FetchProgressData } from "fetch-progress";
 import Between from "between.js";
-import { itemId, PlanItem, setItemPlayed } from "../showplanner/state";
+import { itemId, PlanItem, setItemPlayedAt } from "../showplanner/state";
 import * as BroadcastState from "../broadcast/state";
 import Keys from "keymaster";
 import { Track, MYRADIO_NON_API_BASE, AuxItem } from "../api";
@@ -535,7 +535,10 @@ export const load = (
       // Don't set played on Preview Channel
       if (state.loadedItem != null && player !== PLAYER_ID_PREVIEW) {
         dispatch(
-          setItemPlayed({ itemId: itemId(state.loadedItem), played: true })
+          setItemPlayedAt({
+            itemId: itemId(state.loadedItem),
+            playedAt: new Date().valueOf(),
+          })
         );
       }
     });

--- a/src/navbar/index.tsx
+++ b/src/navbar/index.tsx
@@ -22,7 +22,7 @@ import "./navbar.scss";
 import { closeAlert } from "./state";
 import { ConnectionStateEnum } from "../broadcast/streamer";
 import { VUMeter } from "../optionsMenu/helpers/VUMeter";
-import { getShowplan, setItemPlayed } from "../showplanner/state";
+import { getShowplan, setItemPlayedAt } from "../showplanner/state";
 
 import * as OptionsMenuState from "../optionsMenu/state";
 import { setChannelPFL } from "../mixer/state";
@@ -113,7 +113,9 @@ export function NavBarMyRadio() {
               className="dropdown-item"
               onClick={() =>
                 sessionState.currentTimeslot !== null &&
-                dispatch(setItemPlayed({ itemId: "all", played: false }))
+                dispatch(
+                  setItemPlayedAt({ itemId: "all", playedAt: undefined })
+                )
               }
             >
               Mark All Items Unplayed

--- a/src/showplanner/Item.tsx
+++ b/src/showplanner/Item.tsx
@@ -1,5 +1,11 @@
 import React, { memo } from "react";
-import { PlanItem, itemId, isTrack, isAux } from "./state";
+import {
+  PlanItem,
+  itemId,
+  isTrack,
+  isAux,
+  selPlayedTrackAggregates,
+} from "./state";
 import { Track, AuxItem } from "../api";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../rootReducer";
@@ -13,6 +19,8 @@ import { PLAYER_ID_PREVIEW } from "../mixer/audio";
 
 export const TS_ITEM_MENU_ID = "SongMenu";
 export const TS_ITEM_AUX_ID = "AuxMenu";
+
+const ONE_HOUR_MS = 1000 * 60 * 60;
 
 export const Item = memo(function Item({
   item: x,
@@ -43,7 +51,13 @@ export const Item = memo(function Item({
 
   const partyMode = useSelector((state: RootState) => state.settings.partyMode);
   const showName =
-    !partyMode || column > 2 || !isTrack(x) || ("played" in x && x.played);
+    !partyMode || column > 2 || !isTrack(x) || ("playedAt" in x && x.playedAt);
+
+  const {
+    artists: playedArtists,
+    recordIds: playedRecordids,
+    trackIds: playedTracks,
+  } = useSelector(selPlayedTrackAggregates)!;
 
   function triggerClick() {
     if (column > -1) {
@@ -105,7 +119,9 @@ export const Item = memo(function Item({
           (outroSecs > 60 ? secToHHMM(outroSecs) : outroSecs + " secs")
       );
     }
-    data.push("Played: " + ("played" in x ? (x.played ? "Yes" : "No") : "No"));
+    data.push(
+      "Played: " + ("playedAt" in x ? (x.playedAt ? "Yes" : "No") : "No")
+    );
     data.push(
       "ID: " + ("trackid" in x ? x.trackid : "managedid" in x && x.managedid)
     );
@@ -120,6 +136,27 @@ export const Item = memo(function Item({
     return data.join("¬"); // Something obscure to split against.
   }
 
+  const now = new Date().valueOf();
+  let alreadyPlayedTrack = false,
+    alreadyPlayedArtist = false,
+    alreadyPlayedAlbum = false;
+  if (isTrack(x)) {
+    if (now - (playedTracks.get(x.trackid) || 0) < ONE_HOUR_MS) {
+      alreadyPlayedTrack = true;
+    }
+    if (now - (playedArtists.get(x.artist) || 0) < ONE_HOUR_MS) {
+      alreadyPlayedArtist = true;
+    }
+    if (now - (playedRecordids.get(x.album.recordid) || 0) < ONE_HOUR_MS) {
+      alreadyPlayedAlbum = true;
+    }
+  }
+  const alreadyPlayedClass = alreadyPlayedTrack
+    ? "warn-red"
+    : alreadyPlayedArtist || alreadyPlayedAlbum
+    ? "warn-orange"
+    : "";
+
   return (
     <Draggable draggableId={id} index={index} isDragDisabled={isGhost}>
       {(provided, snapshot) => (
@@ -129,7 +166,7 @@ export const Item = memo(function Item({
           data-itemid={id}
           className={
             "item " +
-            ("played" in x ? (x.played ? "played " : "") : "") +
+            ("playedAt" in x ? (x.playedAt ? "played " : "") : "") +
             x.type +
             `${column >= 0 && isLoaded ? " active" : ""}`
           }
@@ -140,7 +177,7 @@ export const Item = memo(function Item({
           data-tip={generateTooltipData()}
           data-for="track-hover-tooltip"
         >
-          <span className={"icon " + x.type} />
+          <span className={"icon " + x.type + " " + alreadyPlayedClass} />
           &nbsp;
           {showName && (
             <>

--- a/src/showplanner/Item.tsx
+++ b/src/showplanner/Item.tsx
@@ -93,6 +93,27 @@ export const Item = memo(function Item({
     }
   }
 
+  const now = new Date().valueOf();
+  let alreadyPlayedTrack = false,
+    alreadyPlayedArtist = false,
+    alreadyPlayedAlbum = false;
+  if (isTrack(x)) {
+    if (now - (playedTracks.get(x.trackid) || 0) < ONE_HOUR_MS) {
+      alreadyPlayedTrack = true;
+    }
+    if (now - (playedArtists.get(x.artist) || 0) < ONE_HOUR_MS) {
+      alreadyPlayedArtist = true;
+    }
+    if (now - (playedRecordids.get(x.album.recordid) || 0) < ONE_HOUR_MS) {
+      alreadyPlayedAlbum = true;
+    }
+  }
+  const alreadyPlayedClass = alreadyPlayedTrack
+    ? "warn-red"
+    : alreadyPlayedArtist || alreadyPlayedAlbum
+    ? "warn-orange"
+    : "";
+
   function generateTooltipData() {
     let data = [];
     if (partyMode) {
@@ -133,29 +154,15 @@ export const Item = memo(function Item({
           ("channel" in x && x.channel + "/" + x.weight)
       );
     }
+    if (alreadyPlayedTrack) {
+      data.push("Warning: Already played in the last hour!");
+    } else if (alreadyPlayedArtist) {
+      data.push("Warning: Song by same artist played in last hour!");
+    } else if (alreadyPlayedAlbum) {
+      data.push("Warning: Song on same album played in past hour!");
+    }
     return data.join("¬"); // Something obscure to split against.
   }
-
-  const now = new Date().valueOf();
-  let alreadyPlayedTrack = false,
-    alreadyPlayedArtist = false,
-    alreadyPlayedAlbum = false;
-  if (isTrack(x)) {
-    if (now - (playedTracks.get(x.trackid) || 0) < ONE_HOUR_MS) {
-      alreadyPlayedTrack = true;
-    }
-    if (now - (playedArtists.get(x.artist) || 0) < ONE_HOUR_MS) {
-      alreadyPlayedArtist = true;
-    }
-    if (now - (playedRecordids.get(x.album.recordid) || 0) < ONE_HOUR_MS) {
-      alreadyPlayedAlbum = true;
-    }
-  }
-  const alreadyPlayedClass = alreadyPlayedTrack
-    ? "warn-red"
-    : alreadyPlayedArtist || alreadyPlayedAlbum
-    ? "warn-orange"
-    : "";
 
   return (
     <Draggable draggableId={id} index={index} isDragDisabled={isGhost}>

--- a/src/showplanner/index.tsx
+++ b/src/showplanner/index.tsx
@@ -31,7 +31,7 @@ import {
   moveItem,
   addItem,
   removeItem,
-  setItemPlayed,
+  setItemPlayedAt,
   PlanItemBase,
 } from "./state";
 
@@ -140,7 +140,7 @@ const Showplanner: React.FC<{ timeslotId: number }> = function({ timeslotId }) {
         timeslotitemid: "I" + insertIndex,
         channel: parseInt(result.destination.droppableId, 10),
         weight: result.destination.index,
-        played: false,
+        playedAt: undefined,
         cue: 0,
         ...data,
       };
@@ -234,7 +234,10 @@ const Showplanner: React.FC<{ timeslotId: number }> = function({ timeslotId }) {
         <CtxMenuItem
           onClick={(args) =>
             dispatch(
-              setItemPlayed({ itemId: (args.props as any).id, played: false })
+              setItemPlayedAt({
+                itemId: (args.props as any).id,
+                playedAt: undefined,
+              })
             )
           }
         >
@@ -243,7 +246,10 @@ const Showplanner: React.FC<{ timeslotId: number }> = function({ timeslotId }) {
         <CtxMenuItem
           onClick={(args) =>
             dispatch(
-              setItemPlayed({ itemId: (args.props as any).id, played: true })
+              setItemPlayedAt({
+                itemId: (args.props as any).id,
+                playedAt: new Date().valueOf(),
+              })
             )
           }
         >

--- a/src/showplanner/item.scss
+++ b/src/showplanner/item.scss
@@ -39,5 +39,12 @@
     &.ghost {
       background-color: gray;
     }
+
+    &.warn-red {
+      background-color: #ed4040;
+    }
+    &.warn-orange {
+      background-color: #ed9640;
+    }
   }
 }

--- a/src/showplanner/player.scss
+++ b/src/showplanner/player.scss
@@ -1,0 +1,8 @@
+.card-title {
+  &.warn-red {
+    color: #b61f1f;
+  }
+  &.warn-orange {
+    color: #b16d2a;
+  }
+}


### PR DESCRIPTION
Basically
- items that have already been played in the last hour have their disc turn red
- items where the same artist/album has been played in the last hour have their disc turn orange

Considerations
- Performance impact is pretty small - the check is done using a Map, which ensures sub-linear time, and the map computation is cached
- Nevertheless, would it be worth adding a Pro Mode toggle to disable it?
- Artist checks are done using exact text matches - it's not terribly precise (as seen in the screenshot), but it's the algo used by Jukebox already so /shrug

Things I'm not sure about
- The red highlight duplicates the black outline for already played items - do we want to keep that?
  - It is, however, extremely cool in the search box
- Not sure how I feel about the player text colour - I changed it to make it more noticeable when you're about to hit play, but it doesn't look fantastic

![image](https://user-images.githubusercontent.com/2904440/123011913-382fcf80-d3b9-11eb-9863-2319a265472f.png)
![image](https://user-images.githubusercontent.com/2904440/123011920-3bc35680-d3b9-11eb-97ea-2a3658bddf43.png)
![image](https://user-images.githubusercontent.com/2904440/123011890-2b12e080-d3b9-11eb-91e8-cfe74d2451ea.png)
