### PR TITLE
Only import news files when not using BAPSicle.

### DIFF
--- a/src/mixer/audio.ts
+++ b/src/mixer/audio.ts
@@ -4,7 +4,6 @@ import StrictEmitter from "strict-event-emitter-types";
 import WaveSurfer from "wavesurfer.js";
 import CursorPlugin from "wavesurfer.js/dist/plugin/wavesurfer.cursor.min.js";
 import RegionsPlugin from "wavesurfer.js/dist/plugin/wavesurfer.regions.min.js";
-import NewsEndCountdown from "../assets/audio/NewsEndCountdown.wav";
 import NewsIntro from "../assets/audio/NewsIntro.wav";
 
 import StereoAnalyserNode from "stereo-analyser-node";

--- a/src/mixer/audio.ts
+++ b/src/mixer/audio.ts
@@ -4,7 +4,6 @@ import StrictEmitter from "strict-event-emitter-types";
 import WaveSurfer from "wavesurfer.js";
 import CursorPlugin from "wavesurfer.js/dist/plugin/wavesurfer.cursor.min.js";
 import RegionsPlugin from "wavesurfer.js/dist/plugin/wavesurfer.regions.min.js";
-import NewsIntro from "../assets/audio/NewsIntro.wav";
 
 import StereoAnalyserNode from "stereo-analyser-node";
 

--- a/src/mixer/audio.ts
+++ b/src/mixer/audio.ts
@@ -7,8 +7,8 @@ import RegionsPlugin from "wavesurfer.js/dist/plugin/wavesurfer.regions.min.js";
 
 import StereoAnalyserNode from "stereo-analyser-node";
 
-let NewsEndCountdown: any;
-let NewsIntro: any;
+let NewsEndCountdown: string;
+let NewsIntro: string;
 if (!process.env.REACT_APP_BAPSICLE_INTERFACE) {
   NewsEndCountdown = require("../assets/audio/NewsEndCountdown.wav");
   NewsIntro = require("../assets/audio/NewsIntro.wav");

--- a/src/mixer/audio.ts
+++ b/src/mixer/audio.ts
@@ -9,6 +9,13 @@ import NewsIntro from "../assets/audio/NewsIntro.wav";
 
 import StereoAnalyserNode from "stereo-analyser-node";
 
+let NewsEndCountdown: any;
+let NewsIntro: any;
+if (!process.env.REACT_APP_BAPSICLE_INTERFACE) {
+  NewsEndCountdown = require("../assets/audio/NewsEndCountdown.wav");
+  NewsIntro = require("../assets/audio/NewsIntro.wav");
+}
+
 export const DEFAULT_TRIM_DB = -6; // The default trim applied to channel players.
 
 export const OFF_LEVEL_DB = -40;


### PR DESCRIPTION
As far as I can tell, this is how to make webpack not include these files for BAPSicle.

If there's a better way, please let me know.