### PR TITLE
Rework BAPS build to avoid NODE_ENV problems

### DIFF
--- a/config/env.js
+++ b/config/env.js
@@ -14,15 +14,19 @@ if (!NODE_ENV) {
   );
 }
 
+const BAPSICLE =
+  (process.env.REACT_APP_BAPSICLE_INTERFACE || "false") == "true";
+
 // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 const dotenvFiles = [
   `${paths.dotenv}.${NODE_ENV}.local`,
+  BAPSICLE && `${paths.dotenv}.baps-${NODE_ENV}`,
   `${paths.dotenv}.${NODE_ENV}`,
   // Don't include `.env.local` for `test` environment
   // since normally you expect tests to produce the same
   // results for everyone
   NODE_ENV !== "test" && `${paths.dotenv}.local`,
-  paths.dotenv
+  paths.dotenv,
 ].filter(Boolean);
 
 // Load environment variables from .env* files. Suppress warnings using silent
@@ -30,11 +34,11 @@ const dotenvFiles = [
 // that have already been set.  Variable expansion is supported in .env files.
 // https://github.com/motdotla/dotenv
 // https://github.com/motdotla/dotenv-expand
-dotenvFiles.forEach(dotenvFile => {
+dotenvFiles.forEach((dotenvFile) => {
   if (fs.existsSync(dotenvFile)) {
     require("dotenv-expand")(
       require("dotenv").config({
-        path: dotenvFile
+        path: dotenvFile,
       })
     );
   }
@@ -52,8 +56,8 @@ dotenvFiles.forEach(dotenvFile => {
 const appDirectory = fs.realpathSync(process.cwd());
 process.env.NODE_PATH = (process.env.NODE_PATH || "")
   .split(path.delimiter)
-  .filter(folder => folder && !path.isAbsolute(folder))
-  .map(folder => path.resolve(appDirectory, folder))
+  .filter((folder) => folder && !path.isAbsolute(folder))
+  .map((folder) => path.resolve(appDirectory, folder))
   .join(path.delimiter);
 
 // Grab NODE_ENV and REACT_APP_* environment variables and prepare them to be
@@ -62,7 +66,7 @@ const REACT_APP = /^REACT_APP_/i;
 
 function getClientEnvironment(publicUrl) {
   const raw = Object.keys(process.env)
-    .filter(key => REACT_APP.test(key))
+    .filter((key) => REACT_APP.test(key))
     .reduce(
       (env, key) => {
         env[key] = process.env[key];
@@ -79,7 +83,7 @@ function getClientEnvironment(publicUrl) {
         PUBLIC_URL: publicUrl,
         // This is a bodge.
         // See https://github.com/bunkat/later/issues/155
-        LATER_COV: false
+        LATER_COV: false,
       }
     );
   // Stringify all values so we can feed into Webpack DefinePlugin
@@ -87,7 +91,7 @@ function getClientEnvironment(publicUrl) {
     "process.env": Object.keys(raw).reduce((env, key) => {
       env[key] = JSON.stringify(raw[key]);
       return env;
-    }, {})
+    }, {}),
   };
 
   return { raw, stringified };

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -7,7 +7,9 @@ process.env.NODE_ENV = "production";
 // If we want BAPS, specify it as the first command line argument.
 var args = process.argv.slice(2); // Remove node start.js
 if (args.length > 0 && args[0] === "baps") {
-  process.env.NODE_ENV = "baps-production";
+  // We set this here first; later on, in env.js, we'll reference it to load in
+  // the other variables from .env.baps-${NODE_ENV}
+  process.env.REACT_APP_BAPSICLE_INTERFACE = "true";
 }
 
 // Makes the script crash on unhandled rejections instead of silently
@@ -147,7 +149,11 @@ function build(previousFileSizes) {
     console.log();
   }
 
-  console.log("Creating an optimized production build...");
+  console.log(
+    `Creating an optimized production ${
+      process.env.REACT_APP_BAPSICLE_INTERFACE === "true" ? "BAPS" : "WebStudio"
+    } build...`
+  );
 
   const compiler = webpack(config);
   return new Promise((resolve, reject) => {

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -7,7 +7,9 @@ process.env.NODE_ENV = "development";
 // If we want BAPS, specify it as the first command line argument.
 var args = process.argv.slice(2); // Remove node start.js
 if (args.length > 0 && args[0] === "baps") {
-  process.env.NODE_ENV = "baps-development";
+  // We set this here first; later on, in env.js, we'll reference it to load in
+  // the other variables from .env.baps-${NODE_ENV}
+  process.env.REACT_APP_BAPSICLE_INTERFACE = "true";
 }
 
 // Makes the script crash on unhandled rejections instead of silently


### PR DESCRIPTION
Previously we would set NODE_ENV=baps-<env> to signal that this is a BAPS build. However, many libraries rely on NODE_ENV=="production" to activate optimisations, meaning performance tanked.

This commit reorganises it to avoid relying on NODE_ENV changes, while still applying env vars as necessary.