### PR TITLE
Fix WebStudio not marking items played on play.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@babel/core": "7.6.0",
+    "@babel/helper-validator-option": "^7.21.0",
     "@reduxjs/toolkit": "^1.0.4",
     "@sentry/react": "^6.3.1",
     "@sentry/tracing": "^6.3.1",

--- a/src/mixer/state.ts
+++ b/src/mixer/state.ts
@@ -626,7 +626,9 @@ export const load = (
         const state = getState().mixer.players[player];
         // Don't set played on Preview Channel
         if (state.loadedItem != null && player !== PLAYER_ID_PREVIEW) {
-          setItemPlayedAt(itemId(state.loadedItem), new Date().valueOf());
+          dispatch(
+            setItemPlayedAt(itemId(state.loadedItem), new Date().valueOf())
+          );
         }
       });
       playerInstance.on("pause", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -334,6 +334,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
   integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
 
+"@babel/helper-validator-option@^7.21.0":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz#8224c7e13ace4bafdc4004da2cf064ef42673180"
+  integrity sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==
+
 "@babel/helper-wrap-function@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz#9dbdb2bb55ef14aaa01fe8c99b629bd5352d8610"


### PR DESCRIPTION
After the BAPSicle merge, items are not marked as played when pressing play because the call is not dispatched.