### PR TITLE
Fix Preview Channel following autoadvance.

### DIFF
--- a/src/mixer/state.ts
+++ b/src/mixer/state.ts
@@ -100,11 +100,19 @@ const BasePlayerState: PlayerState = {
   loadError: false,
 };
 
+// Override any settings for the preview player
+const PreviewPlayerState: PlayerState = {
+  ...BasePlayerState,
+  autoAdvance: false,
+};
+const playersInitialState = Array(PLAYER_COUNT).fill(BasePlayerState);
+playersInitialState[PLAYER_ID_PREVIEW] = PreviewPlayerState;
+
 const mixerState = createSlice({
   name: "Player",
   initialState: {
     // Fill the players with channel and preview players.
-    players: Array(PLAYER_COUNT).fill(BasePlayerState),
+    players: playersInitialState,
     mic: {
       open: false,
       volume: 1,

--- a/src/showplanner/Player.tsx
+++ b/src/showplanner/Player.tsx
@@ -383,6 +383,11 @@ export function Player({ id }: { id: number }) {
     if (id < PLAYER_COUNT) {
       return ("player-" + id) as LevelsSource;
     }
+    // We don't want the Preview channel doing anything silly, overwrite default player settings.
+    if (isPreviewChannel) {
+      dispatch(MixerState.setAutoAdvance({ player: id, enabled: false }));
+    }
+
     throw new Error("Unknown Player VUMeter source: " + id);
   };
 

--- a/src/showplanner/Player.tsx
+++ b/src/showplanner/Player.tsx
@@ -383,11 +383,6 @@ export function Player({ id }: { id: number }) {
     if (id < PLAYER_COUNT) {
       return ("player-" + id) as LevelsSource;
     }
-    // We don't want the Preview channel doing anything silly, overwrite default player settings.
-    if (isPreviewChannel) {
-      dispatch(MixerState.setAutoAdvance({ player: id, enabled: false }));
-    }
-
     throw new Error("Unknown Player VUMeter source: " + id);
   };
 

--- a/src/showplanner/Player.tsx
+++ b/src/showplanner/Player.tsx
@@ -345,15 +345,11 @@ function LoadedTrackInfo({ id }: { id: number }) {
   );
 }
 
-export function Player({
-  id,
-  isPreviewChannel,
-}: {
-  id: number;
-  isPreviewChannel: boolean;
-}) {
+export function Player({ id }: { id: number }) {
   // Define time remaining (secs) when the play icon should flash.
   const SECS_REMAINING_WARNING = 20;
+
+  const isPreviewChannel = id === PLAYER_ID_PREVIEW;
 
   // We want to force update the selector when we pass the SECS_REMAINING_WARNING barrier.
   const playerState = useSelector(
@@ -620,7 +616,7 @@ export function PflPlayer() {
       <span className="mx-1 hover-label always-show">
         Preview Player (Headphones Only)
       </span>
-      <Player id={PLAYER_ID_PREVIEW} isPreviewChannel={true} />
+      <Player id={PLAYER_ID_PREVIEW} />
     </div>
   );
 }

--- a/src/showplanner/index.tsx
+++ b/src/showplanner/index.tsx
@@ -70,7 +70,7 @@ function Channel({ id, data }: { id: number; data: PlanItem[] }) {
           </div>
         )}
       </Droppable>
-      <Player id={id} isPreviewChannel={false} />
+      <Player id={id} />
     </div>
   );
 }


### PR DESCRIPTION
Right clicking an item and using "Preview with PFL" would autoadvance if you reached the end of the track.

This was because when using this feature, the item loaded in would have a "channel" value from the channel it was right clicked from. (https://github.com/UniversityRadioYork/WebStudio/pull/288/files#diff-9524f2b844c217fb24697a0798239f14aa078bf29e2d88c41803ccf97ea2b512R669)

Regular sidebar searching for items doesn't exhibit this behaviour because they don't have the "channel" value, so the autoAdvance etc logic doesn't run.
