### PR TITLE
BAPSicle: Add button to open showplan from ID

### DIFF
--- a/src/navbar/loadshow.tsx
+++ b/src/navbar/loadshow.tsx
@@ -5,6 +5,7 @@ import {
   FaCircleNotch,
   FaCog,
   FaDownload,
+  FaKeyboard,
   FaSearch,
   FaTimesCircle,
   FaTrashAlt,
@@ -58,6 +59,17 @@ export function LoadShowDialogue({ close }: { close: () => any }) {
         }}
       >
         <FaCircleNotch size={15} /> Mark All Unplayed
+      </div>
+      <div
+        className="btn btn-outline-dark outline float-right mr-1"
+        onClick={() => {
+          sendBAPSicleChannel({
+            command: "GETPLAN",
+            timeslotId: window.prompt("Enter timeslot ID"),
+          });
+        }}
+      >
+        <FaKeyboard size={15} /> Enter Show ID
       </div>
 
       <h2>Load Show</h2>


### PR DESCRIPTION
This change will only show when webstudio is run in BAPS mode while BAPS server is running https://github.com/UniversityRadioYork/BAPSicle

This PR adds a button to the load show plan page where any show can be loaded from just the showplan ID. This can be found in the top right menu of webstudio. 

Addition is largely motivated by training where an example showplan can be loaded for demonstration purposes.