### PR TITLE
FIX: Load from specific show ID

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -212,3 +212,7 @@ button {
 .ReactModal__Overlay {
   z-index: 10000;
 }
+
+.cursor-pointer {
+  cursor: pointer;
+}

--- a/src/navbar/index.tsx
+++ b/src/navbar/index.tsx
@@ -125,7 +125,14 @@ export function NavBarMyRadio() {
             <h6 className="dropdown-header">
               {sessionState.currentTimeslot?.title}
             </h6>
-            <h6 className="dropdown-header">
+            <h6
+              className="dropdown-header cursor-pointer"
+              onClick={() => {
+                navigator.clipboard.writeText(
+                  sessionState.currentTimeslot?.timeslot_id.toString() || ""
+                );
+              }}
+            >
               ID: {sessionState.currentTimeslot?.timeslot_id}
             </h6>
           </div>

--- a/src/navbar/loadshow.tsx
+++ b/src/navbar/loadshow.tsx
@@ -16,8 +16,15 @@ type searchingStateEnum = "searching" | "results" | "no-results" | "error";
 
 export function LoadShowDialogue({ close }: { close: () => any }) {
   const [items, setItems] = useState<Timeslot[]>([]);
+  const [customTimeslotID, _setCustomTimeslotID] = useState("");
+  const [isInvalidShowId, setIsInvalidShowId] = useState(false);
 
   const [state, setState] = useState<searchingStateEnum>("searching");
+
+  const setCustomTimeslotID = (value: string) => {
+    _setCustomTimeslotID(value);
+    setIsInvalidShowId(false);
+  };
 
   useEffect(() => {
     getTimeslots().then((timeslots) => {
@@ -61,16 +68,33 @@ export function LoadShowDialogue({ close }: { close: () => any }) {
         <FaCircleNotch size={15} /> Mark All Unplayed
       </div>
       <div
-        className="btn btn-outline-dark outline float-right mr-1"
+        className="btn btn-outline-dark outline float-right mr-4"
         onClick={() => {
-          sendBAPSicleChannel({
-            command: "GETPLAN",
-            timeslotId: window.prompt("Enter timeslot ID"),
-          });
+          // check input is a number
+          if (isNaN(parseInt(customTimeslotID))) {
+            console.log("Invalid show ID provided; not loaded");
+            setIsInvalidShowId(true);
+          } else {
+            sendBAPSicleChannel({
+              command: "GETPLAN",
+              timeslotId: customTimeslotID,
+            });
+            close();
+          }
         }}
       >
-        <FaKeyboard size={15} /> Enter Show ID
+        <FaKeyboard size={15} /> Load Show ID
       </div>
+      <input
+        className={
+          "form-control form-control-sm outline float-right mr-1 mt-1 w-25 p-1" +
+          (isInvalidShowId ? " is-invalid" : "")
+        }
+        type="text"
+        placeholder="Enter Show ID..."
+        value={customTimeslotID}
+        onChange={(e) => setCustomTimeslotID(e.target.value)}
+      />
 
       <h2>Load Show</h2>
       <ResultsPlaceholder state={state} />

--- a/src/navbar/loadshow.tsx
+++ b/src/navbar/loadshow.tsx
@@ -110,6 +110,7 @@ export function LoadShowDialogue({ close }: { close: () => any }) {
                     command: "GETPLAN",
                     timeslotId: item.timeslot_id,
                   });
+                  close();
                 }}
               >
                 <FaDownload size={15} /> Load Show Plan


### PR DESCRIPTION
## BAPS

Fix for lack of Alert box popup in neutron studio. 

Now gets user input from text box on screen. Minimal validation on this just enough to not explode everything when someone does something silly. 

To facilitate this too, the show ID that displays in the webstudio navbar dropdown is clickable and copies the ID to clipboard so this is easier to find for people.

## Webstudio:

This build also closes the showplan when a load button is clicked.

## Image:

![image](https://github.com/user-attachments/assets/16c98bd1-f669-4f7d-bf66-469d9ea20fc4)
